### PR TITLE
Added git support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -31,9 +31,20 @@ command.
 This rake task goes through the modules that are declared in the Puppetfile,
 and prints outdated modules.
 
+Supports:
+  - Puppet Forge
+  - Git (SHA-ref and Tagging)
+
+Ignoring specific modules:
+
+Under specific conditions you may not wish to report on specific modules being out of date,
+to ignore a module create `.r10kignore` file in the same directory as your Puppetfile.
+
 #### Limitations
 
-  * It works only with modules from the [Forge](https://forge.puppetlabs.com).
-  Git and SVN modules will be ignored.
+  * It works only with modules from the [Forge](https://forge.puppetlabs.com), and Git.
+  SVN modules will be ignored.
+  * Git support is explicitly SHA Ref and Tag supported. If tag is used it must follow
+  `v0.0.0` convention, other wise it will be ignored.
   * The version has to be specified explicitly. If it is omitted, or it is
   `:latest`, the module will be ignored.

--- a/lib/ra10ke.rb
+++ b/lib/ra10ke.rb
@@ -1,6 +1,7 @@
 require 'rake'
 require 'rake/tasklib'
 require 'ra10ke/version'
+require 'git'
 
 module Ra10ke
   class RakeTask < ::Rake::TaskLib
@@ -15,7 +16,14 @@ module Ra10ke
           puppetfile = R10K::Puppetfile.new('.')
           puppetfile.load!
 
+          # ignore file allows for "don't tell me about this"
+          ignore_modules = []
+          if File.exist?('.r10kignore')
+            ignore_modules = File.readlines('.r10kignore').each {|l| l.chomp!}
+          end
+
           puppetfile.modules.each do |puppet_module|
+            next if ignore_modules.include? puppet_module.title
             if puppet_module.class == R10K::Module::Forge
               module_name = puppet_module.title.gsub('/', '-')
               forge_version = PuppetForge::Module.find(module_name).current_release.version
@@ -23,6 +31,39 @@ module Ra10ke
               if installed_version != forge_version
                 puts "#{puppet_module.title} is OUTDATED: #{installed_version} vs #{forge_version}"
               end
+            end
+
+            if puppet_module.class == R10K::Module::Git
+              remote = puppet_module.instance_variable_get(:@remote)
+              ref    = puppet_module.instance_variable_get(:@desired_ref)
+
+              # some guards to prevent unnessicary execution
+              next unless ref
+              next if ref == 'master'
+
+              remote_refs = Git.ls_remote(remote)
+
+              # skip if ref is a branch
+              next if remote_refs['branches'].key?(ref)
+
+              ref_type = 'sha'    if ref.match(/^[a-z0-9]{40}$/)
+              ref_type = 'tag'    if remote_refs['tags'].key?(ref)
+              case ref_type
+              when 'sha'
+                latest_ref = remote_refs['head'][:sha]
+              when 'tag'
+                # we have to be opinionated here, due to multiple conventions only one can reign suppreme
+                # as such tag v#.#.# is what will pick.
+                if ref.match(/^[vV]\d/)
+                  tags = remote_refs['tags']
+                  version_tags = tags.select { |f| /^[vV]\d/.match(f) }
+                  latest_ref = version_tags.keys.sort.last
+                end
+              else
+                raise "Unable to determine ref_type for #{puppet_module.title}"
+              end
+
+              puts "#{puppet_module.title} is OUTDATED: #{ref} vs #{latest_ref}" if ref != latest_ref
             end
           end
         end

--- a/ra10ke.gemspec
+++ b/ra10ke.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rake"
   spec.add_dependency "puppet_forge"
   spec.add_dependency "r10k"
+  spec.add_dependency "git"
 end


### PR DESCRIPTION
Unfortunately utilizing the forge is not always an option, either due to the forge being out of sync with code out on github, or security requirements not permitting the releasing of internal code into the public sphere.

As such it is quite common to have an extensive deployment of private code spanning multiple puppet environments internally. As such this change allows for querying refs via git ls-remote and attempting to resolve out of date status. Authentication if needed is done via environmental variables (such as ssh keys or git global config). 

When a module is pinned to an SHA ref HEAD on the remote repository is compared to determine outdated status.

Special note on tags... I could not figure out a less opinionated way to evaluate tagging other than to only function if the tag matches /^v\d/ or in human readable v1.2.3 or v1 or v1.2 so I am open to suggestions if this seems too opinionated

Additionally I have added the usage of an .r10kignore file which effectively is a list of modules (one per line) of which we do not want to be notified about outdated status.

Thanks!
