### PR TITLE
Avoid using `desired_ref` directly for Git

### DIFF
--- a/lib/ra10ke.rb
+++ b/lib/ra10ke.rb
@@ -36,11 +36,11 @@ module Ra10ke
 
             if puppet_module.class == R10K::Module::Git
               remote = puppet_module.instance_variable_get(:@remote)
-              ref    = puppet_module.instance_variable_get(:@desired_ref)
 
-              # some guards to prevent unnessicary execution
+              # use helper; avoid `desired_ref`
+              # we do not want to deal with `:control_branch`
+              ref = puppet_module.version
               next unless ref
-              next if ref == 'master'
 
               remote_refs = Git.ls_remote(remote)
 


### PR DESCRIPTION
Use the exposed helper aptly called `version` instead of trying to deal with the messy `desired_ref` which can sometimes be set as `:control_branch` especially for people with newer Puppetfiles and crazy branching strategies.

See #10.