### PR TITLE
Set required Ruby version as `>= 2.1.0`

### DIFF
--- a/ra10ke.gemspec
+++ b/ra10ke.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files`.split($/)
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 2.1.0'
 
   spec.add_dependency "rake"
   spec.add_dependency "puppet_forge"


### PR DESCRIPTION
As we use `solve` and it [requires Ruby `>= 2.1.0`](https://github.com/berkshelf/solve/blob/e53a2305bb7ff5ef161dc5181a401b45d425ace6/solve.gemspec#L17), we can be explicit in our Gem Spec as well.

See #9.