### PR TITLE
ignore invalid ref

### DIFF
--- a/lib/ra10ke.rb
+++ b/lib/ra10ke.rb
@@ -57,7 +57,7 @@ module Ra10ke
                 # v#.#.# or #.#.# is what we will pick.
                 if ref.match(/^[vV]?\d[\.\d]*/)
                   tags = remote_refs['tags']
-                  version_tags = tags.select { |f| /^[vV]?\d[\.\d]*/.match(f) }
+                  version_tags = tags.select { |f| /^[vV]?\d[\.\d]*$/.match(f) }
                   latest_ref = version_tags.keys.sort.last
                 else
                   latest_ref = "undef (tags don't match v#.#.# or #.#.#)"


### PR DESCRIPTION
some modules have weird tags.
e.g.
puppetlabs-git
```
git ls-remote https://github.com/puppetlabs/puppetlabs-git.git | tail -3
cfbf74dbb370f00d1349d8589ba0d963d5d503eb	refs/tags/0.4.0^{}
a0cf10a8cec8728abb008fdd778e243e84dde62c	refs/tags/0.5.0
f7e4ff5cc0b8e887ff07579bb383ce9e173fb93c	refs/tags/0.5.0^{}
```
ra10ke reports this as outdated:

git is OUTDATED: 0.5.0 vs 0.5.0^{}

This fix ensures that we only use correct version tags