### PR TITLE
Use Semantic Versioning for Git tags

### DIFF
--- a/ra10ke.gemspec
+++ b/ra10ke.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "r10k"
   spec.add_dependency "git"
   spec.add_dependency "solve"
+  spec.add_dependency 'semverse', '~> 2.0'
 end


### PR DESCRIPTION
Following the quick notes in f20ba1267962a9b23f22346550f61c56886206da here is a proposal for dealing with Git tags without using regular expressions - use [Semantic Versioning](https://semver.org/spec/v2.0.0.html) instead.

This PR removes support for `X` and `X.Y` version tags, but supports `vX.Y.Z` along with `X.Y.Z` and full SemVer tags such as `v2.3.1-rc.2+20180405`. If there is a reason to add support for the `X` and `X.Y` formats, those can be squeezed in.