### PR TITLE
Fix a fault in the mod handling behaviour

### DIFF
--- a/lib/ra10ke/puppetfile_parser.rb
+++ b/lib/ra10ke/puppetfile_parser.rb
@@ -23,8 +23,8 @@ module Ra10ke
 
           all_lines = File.read(puppetfile).lines.map(&:strip_comment)
           # remove comments from all the lines
-          lines_without_comments = all_lines.reject { |line| line.match(/#.*\n/) }.join("\n").delete("\n")
-          lines_without_comments.split('mod').map do |line|
+          lines_without_comments = all_lines.reject { |line| line.match(/#.*\n/) }.join("\n")
+          lines_without_comments.split(/^mod/).map do |line|
             next nil if line =~ /^forge/
             next nil if line.empty?
 

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -41,3 +41,7 @@ mod 'dotfiles',
 mod 'splunk',
     git: 'https://github.com/cudgel/splunk.git',
     branch: 'prod'
+
+mod 'puppet',
+    git: 'https://github.com/voxpupuli/puppet-module.git',
+    branch: 'master'

--- a/spec/ra10ke/puppetfile_parser_spec.rb
+++ b/spec/ra10ke/puppetfile_parser_spec.rb
@@ -45,6 +45,9 @@ RSpec.describe 'Ra10ke::PuppetfileParser' do
               :namespace=>nil},
              {:args=>{:branch=>"prod", :git=>"https://github.com/cudgel/splunk.git"},
               :name=>"splunk",
+              :namespace=>nil},
+             {:args=>{:branch=>"master", :git=>"https://github.com/voxpupuli/puppet-module.git"},
+              :name=>"puppet",
               :namespace=>nil}]
     end
 
@@ -85,6 +88,9 @@ RSpec.describe 'Ra10ke::PuppetfileParser' do
            :namespace=>nil},
           {:args=>{:branch=>"prod", :git=>"https://github.com/cudgel/splunk.git"},
            :name=>"splunk",
+           :namespace=>nil},
+          {:args=>{:branch=>"master", :git=>"https://github.com/voxpupuli/puppet-module.git"},
+           :name=>"puppet",
            :namespace=>nil}]
         expect(git_modules(puppetfile)).to eq(expected)
     end


### PR DESCRIPTION
If a module's Git URL contains the word 'mod', then it's split at that point and handled as two modules, this causes the `rake r10k:validate` task to fail quite spectacularly - among other things.