### PR TITLE
Add coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
+coverage
 pkg
 .bundle

--- a/ra10ke.gemspec
+++ b/ra10ke.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'table_print', '~> 1.5.6'
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'pry'
-
+  spec.add_development_dependency 'simplecov'
 end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,24 @@
+# frozen_string_literal: true
+require 'simplecov'
+
+module SimpleCov::Configuration
+  def clean_filters
+    @filters = []
+  end
+end
+
+SimpleCov.configure do
+  clean_filters
+  load_profile 'test_frameworks'
+end
+
+SimpleCov.start do
+  add_filter '/.rvm/'
+  add_filter 'vendor'
+  add_filter 'bundler'
+end if ENV['COVERAGE']
+
+
 def fixtures_dir
     File.join(__dir__, 'fixtures')
 end


### PR DESCRIPTION
  * previously there was not a way to produce coverage reports.
    This adds the simplecov gem and allows you to enable coverage
    by setting COVERAGE=true environment variable when running tests.

    Reports are available under coverage directory when run.