### PR TITLE
Support r10k:validate with control_branch modules

### DIFF
--- a/lib/ra10ke/git_repo.rb
+++ b/lib/ra10ke/git_repo.rb
@@ -8,10 +8,19 @@ module Ra10ke
 
     REMOTE_REFS_CMD = 'git ls-remote --symref'
     CLONE_CMD = 'git clone --no-tags'
+    CURRENT_BRANCH_CMD = 'git symbolic-ref --short HEAD'
     SHOW_CMD = 'git show'
 
     def initialize(url)
       @url = url
+    end
+
+    # @return [String] - The current active branch of the Git repo
+    def current_branch
+      @current_branch ||= begin
+        data, success = run_command(CURRENT_BRANCH_CMD)
+        success ? data.strip : nil
+      end
     end
 
     # @return [Array] - the raw data from the git ls-remote command as lines array

--- a/lib/ra10ke/validate.rb
+++ b/lib/ra10ke/validate.rb
@@ -48,7 +48,7 @@ module Ra10ke
             repo = Ra10ke::GitRepo.new(mod[:args][:git])
             ref = mod[:args][:ref] || mod[:args][:tag] || mod[:args][:branch]
             # If using control_branch, try to guesstimate what the target branch should be
-            ref = ENV['CONTROL_BRANCH'] || repo.current_branch || ENV['FALLBACK_CONTROL_BRANCH'] || 'main' \
+            ref = ENV['CONTROL_BRANCH'] || repo.current_branch || ENV['CONTROL_BRANCH_FALLBACK'] || 'main' \
               if ref == ':control_branch'
             valid_ref = repo.valid_ref?(ref) || repo.valid_commit?(mod[:args][:ref])
             {

--- a/lib/ra10ke/validate.rb
+++ b/lib/ra10ke/validate.rb
@@ -13,7 +13,7 @@ module Ra10ke
     BAD_EMOJI = ENV['BAD_EMOJI'] || '😨'
 
     # Validate the git urls and refs
-    def define_task_validate(*args)
+    def define_task_validate(*)
       desc 'Validate the git urls and branches, refs, or tags'
       task :validate do
         gitvalididation = Ra10ke::Validate::Validation.new(get_puppetfile.puppetfile_path)
@@ -32,7 +32,7 @@ module Ra10ke
 
     class Validation
       include Ra10ke::PuppetfileParser
-      
+
       attr_reader :puppetfile
 
       def initialize(file)
@@ -47,6 +47,9 @@ module Ra10ke
           git_modules(puppetfile).map do |mod|
             repo = Ra10ke::GitRepo.new(mod[:args][:git])
             ref = mod[:args][:ref] || mod[:args][:tag] || mod[:args][:branch]
+            # If using control_branch, try to guesstimate what the target branch should be
+            ref = ENV['CONTROL_BRANCH'] || repo.current_branch || ENV['FALLBACK_CONTROL_BRANCH'] || 'main' \
+              if ref == ':control_branch'
             valid_ref = repo.valid_ref?(ref) || repo.valid_commit?(mod[:args][:ref])
             {
               name: mod[:name],

--- a/spec/fixtures/Puppetfile_with_control_branch
+++ b/spec/fixtures/Puppetfile_with_control_branch
@@ -1,0 +1,12 @@
+mod 'puppet-hiera_master',
+  git: 'https://github.com/voxpupuli/puppet-hiera_master.git',
+  branch: master
+
+mod 'puppet-hiera_control',
+  git: 'https://github.com/voxpupuli/puppet-hiera_control.git',
+  branch: :control_branch
+
+mod 'puppet-hiera_fakecontrol',
+  git: 'https://github.com/voxpupuli/puppet-hiera_fakecontrol.git',
+  branch: control_branch
+  

--- a/spec/ra10ke/validate_spec.rb
+++ b/spec/ra10ke/validate_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe 'Ra10ke::Validate::Validation' do
 
   describe 'control_branch' do
     before(:each) do
+      ENV.delete 'CONTROL_BRANCH'
+      ENV.delete 'CONTROL_BRANCH_FALLBACK'
       allow_any_instance_of(Ra10ke::GitRepo).to receive(:valid_ref?).and_return(true)
       allow_any_instance_of(Ra10ke::GitRepo).to receive(:valid_url?).and_return(true)
     end
@@ -45,23 +47,23 @@ RSpec.describe 'Ra10ke::Validate::Validation' do
 
     it 'correctly replaces control branch' do
       ENV['CONTROL_BRANCH'] = 'env-control_branch'
-      expect(instance.all_modules.all? { |mod| mod[:ref] == 'env-control_branch' })
+      expect(instance.all_modules.find_all { |mod| mod[:ref] == 'env-control_branch' }.count).to eq(1)
     end
 
     it 'correctly detects current branch' do
       allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return('current_branch-control_branch')
-      expect(instance.all_modules.all? { |mod| mod[:ref] == 'current_branch-control_branch' })
+      expect(instance.all_modules.find_all { |mod| mod[:ref] == 'current_branch-control_branch' }.count).to eq(1)
     end
 
     it 'correctly falls back if no current branch' do
       ENV['CONTROL_BRANCH_FALLBACK'] = 'env-control_branch_fallback'
       allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
-      expect(instance.all_modules.all? { |mod| mod[:ref] == 'env-control_branch_fallback' })
+      expect(instance.all_modules.find_all { |mod| mod[:ref] == 'env-control_branch_fallback' }.count).to eq(1)
     end
 
     it 'correctly falls back to main if no current branch and no fallback' do
       allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
-      expect(instance.all_modules.all? { |mod| mod[:ref] == 'main' })
+      expect(instance.all_modules.find_all { |mod| mod[:ref] == 'main' }.count).to eq(1)
     end
   end
 

--- a/spec/ra10ke/validate_spec.rb
+++ b/spec/ra10ke/validate_spec.rb
@@ -18,14 +18,50 @@ RSpec.describe 'Ra10ke::Validate::Validation' do
     let(:instance) do
       Ra10ke::Validate::Validation.new(puppetfile)
     end
-  
+
     let(:puppetfile) do
       File.join(fixtures_dir, 'Puppetfile_with_bad_refs')
     end
 
-    it 'details mods that are bad' do     
+    it 'details mods that are bad' do
       expect(instance.all_modules.find {|m| ! m[:valid_url?]}).to be_a Hash
       expect(instance.all_modules.find_all {|m| ! m[:valid_ref?]}.count).to eq(2)
+    end
+  end
+
+  describe 'control_branch' do
+    before(:each) do
+      allow_any_instance_of(Ra10ke::GitRepo).to receive(:valid_ref?).and_return(true)
+      allow_any_instance_of(Ra10ke::GitRepo).to receive(:valid_url?).and_return(true)
+    end
+
+    let(:instance) do
+      Ra10ke::Validate::Validation.new(puppetfile)
+    end
+
+    let(:puppetfile) do
+      File.join(fixtures_dir, 'Puppetfile_with_control_branch')
+    end
+
+    it 'correctly replaces control branch' do
+      ENV['CONTROL_BRANCH'] = 'env-control_branch'
+      expect(instance.all_modules.all? { |mod| mod[:ref] == 'env-control_branch' })
+    end
+
+    it 'correctly detects current branch' do
+      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return('current_branch-control_branch')
+      expect(instance.all_modules.all? { |mod| mod[:ref] == 'current_branch-control_branch' })
+    end
+
+    it 'correctly falls back if no current branch' do
+      ENV['CONTROL_BRANCH_FALLBACK'] = 'env-control_branch_fallback'
+      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
+      expect(instance.all_modules.all? { |mod| mod[:ref] == 'env-control_branch_fallback' })
+    end
+
+    it 'correctly falls back to main if no current branch and no fallback' do
+      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
+      expect(instance.all_modules.all? { |mod| mod[:ref] == 'main' })
     end
   end
 


### PR DESCRIPTION
This will - when running into a module with control_branch - attempt to
get the correct branch first from the environment variable CONTROL_BRANCH,
followed by the current git repo branch, then the environment variable
CONTROL_BRANCH_FALLBACK, and finally failing over to assume it to be 'main'

Fixes #58