### PR TITLE
Add r10k:deprecation task

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,22 @@ gitlab:
 
 Error: Duplicates exist in the Puppetfile
 ```
+
+### r10k:deprecation
+
+This rake task checks all the Forge modules listed in the Puppetfile, looking
+for modules that are marked as deprecated on the Forge.
+
+Example
+
+```
+NAME                    | DEPRECATED_AT            
+------------------------|--------------------------
+kemra102-auditd         | 2021-07-22 12:11:46      
+puppet-staging          | 2018-12-18 11:11:29      
+puppetlabs-resource_api | 2021-03-31 12:53:24      
+puppetlabs-ruby         | 2021-04-22 10:29:42      
+puppetlabs-translate    | 2021-03-19 10:11:51      
+
+Error: Puppetfile contains deprecated modules.
+```

--- a/lib/ra10ke.rb
+++ b/lib/ra10ke.rb
@@ -4,6 +4,7 @@ require 'ra10ke/version'
 require 'ra10ke/solve'
 require 'ra10ke/syntax'
 require 'ra10ke/dependencies'
+require 'ra10ke/deprecation'
 require 'ra10ke/duplicates'
 require 'ra10ke/install'
 require 'ra10ke/validate'
@@ -15,6 +16,7 @@ module Ra10ke
     include Ra10ke::Solve
     include Ra10ke::Syntax
     include Ra10ke::Dependencies
+    include Ra10ke::Deprecation
     include Ra10ke::Duplicates
     include Ra10ke::Install
     include Ra10ke::Validate
@@ -35,6 +37,7 @@ module Ra10ke
         define_task_solve_dependencies(*args)
         define_task_syntax(*args)
         define_task_dependencies(*args)
+        define_task_deprecation(*args)
         define_task_duplicates(*args)
         define_task_install(*args)
         define_task_validate(*args)

--- a/lib/ra10ke/deprecation.rb
+++ b/lib/ra10ke/deprecation.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'ra10ke/puppetfile_parser'
+require 'English'
+require 'puppet_forge'
+require 'table_print'
+require 'time'
+
+module Ra10ke::Deprecation
+  # Validate the git urls and refs
+  def define_task_deprecation(*)
+    desc 'Validate that no forge modules are deprecated'
+    task :deprecation do
+      valid = Ra10ke::Deprecation::Validation.new(get_puppetfile.puppetfile_path)
+      exit_code = 0
+      if valid.bad_mods?
+        exit_code = 1
+        message = "\nError: Puppetfile contains deprecated modules."
+        tp valid.sorted_mods, :name, :deprecated_at
+      else
+        message = 'Puppetfile contains no deprecated Forge modules.'
+      end
+      abort(message) if exit_code.positive?
+
+      puts message
+    end
+  end
+
+  class Validation
+    include Ra10ke::PuppetfileParser
+
+    attr_reader :puppetfile
+
+    def initialize(file)
+      file ||= './Puppetfile'
+      @puppetfile = File.expand_path(file)
+      abort("Puppetfile does not exist at #{puppetfile}") unless File.readable?(puppetfile)
+    end
+
+    # @return [Array[Hash]] array of module information and git status
+    def deprecated_modules
+      @deprecated_modules ||= begin
+        deprecated = forge_modules(puppetfile).map do |mod|
+          module_name = "#{mod[:namespace] || mod[:name]}-#{mod[:name]}"
+          forge_data = PuppetForge::Module.find(module_name)
+
+          next forge_data if forge_data.deprecated_at
+
+          nil
+        rescue Faraday::ResourceNotFound
+          nil
+        end
+        deprecated.compact.map do |mod|
+          { name: mod.slug, deprecated_at: Time.parse(mod.deprecated_at) }
+        end
+      end
+    end
+
+    # @return [Boolean] - true if there are any bad mods
+    def bad_mods?
+      deprecated_modules.any?
+    end
+
+    # @return [Hash] - sorts the mods based on good/bad
+    def sorted_mods
+      deprecated_modules.sort_by { |a| a[:name] }
+    end
+  end
+end

--- a/lib/ra10ke/deprecation.rb
+++ b/lib/ra10ke/deprecation.rb
@@ -41,14 +41,17 @@ module Ra10ke::Deprecation
     def deprecated_modules
       @deprecated_modules ||= begin
         deprecated = forge_modules(puppetfile).map do |mod|
-          module_name = "#{mod[:namespace] || mod[:name]}-#{mod[:name]}"
-          forge_data = PuppetForge::Module.find(module_name)
+          # For Ruby 2.4 support
+          begin # rubocop:disable Style/RedundantBegin
+            module_name = "#{mod[:namespace] || mod[:name]}-#{mod[:name]}"
+            forge_data = PuppetForge::Module.find(module_name)
 
-          next forge_data if forge_data.deprecated_at
+            next forge_data if forge_data.deprecated_at
 
-          nil
-        rescue Faraday::ResourceNotFound
-          nil
+            nil
+          rescue Faraday::ResourceNotFound
+            nil
+          end
         end
         deprecated.compact.map do |mod|
           { name: mod.slug, deprecated_at: Time.parse(mod.deprecated_at) }

--- a/lib/ra10ke/puppetfile_parser.rb
+++ b/lib/ra10ke/puppetfile_parser.rb
@@ -12,6 +12,13 @@ module Ra10ke
         end
       end
 
+      # @return [Array] - returns a array of hashes that contain modules from the Forge
+      def forge_modules(file = puppetfile)
+        modules(file).reject do |mod|
+          mod[:args].key?(:git)
+        end
+      end
+
       # @param puppetfile [String] - the absolute path to the puppetfile
       # @return [Array] - returns an array of module hashes that represent the puppetfile
       # @example

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -2,7 +2,9 @@
 
 forge 'http://forge.puppetlabs.com'
 
+mod 'choria/choria',          '0.26.2'
 mod 'puppetlabs/inifile',     '2.2.0'
+mod 'puppetlabs-ruby',        '1.0.1'
 mod 'puppetlabs/stdlib',      '4.24.0'
 mod 'puppetlabs/concat',      '4.0.0'
 mod 'puppetlabs/ntp',         '6.4.1'

--- a/spec/ra10ke/deprecation_spec.rb
+++ b/spec/ra10ke/deprecation_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ra10ke/deprecation'
+RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
+RSpec.describe 'Ra10ke::Deprecation::Validation' do
+  let(:instance) do
+    Ra10ke::Deprecation::Validation.new(puppetfile)
+  end
+
+  let(:puppetfile) do
+    File.join(fixtures_dir, 'Puppetfile')
+  end
+
+  it 'only checks forge modules' do
+    expect(PuppetForge::Module).to_not receive(:find).with('puppet')
+    allow(PuppetForge::Module).to receive(:find).and_raise(Faraday::ResourceNotFound.new(nil))
+    expect(instance.deprecated_modules.count).to eq(0)
+  end
+
+  it 'handles deprecated modules' do
+    expect(PuppetForge::Module).to receive(:find).with('puppetlabs-ruby').and_return(double(slug: 'puppetlabs-ruby', deprecated_at: '2021-04-22 10:29:42 -0700'))
+    allow(PuppetForge::Module).to receive(:find).and_return(double(slug: 'module-module', deprecated_at: nil))
+
+    expect(instance.bad_mods?).to eq(true)
+    expect(instance.deprecated_modules.first).to eq(name: 'puppetlabs-ruby', deprecated_at: Time.parse('2021-04-22 10:29:42 -0700'))
+  end
+
+  it 'handles missing modules' do
+    expect(PuppetForge::Module).to receive(:find).with('choria-choria').and_return(double(slug: 'choria-choria', deprecated_at: nil))
+    expect(PuppetForge::Module).to receive(:find).with('puppetlabs-ruby').and_raise(Faraday::ResourceNotFound.new(nil))
+    allow(PuppetForge::Module).to receive(:find).and_return(double(slug: 'module-module', deprecated_at: nil))
+
+    expect(instance.bad_mods?).to eq(false)
+  end
+end

--- a/spec/ra10ke/puppetfile_parser_spec.rb
+++ b/spec/ra10ke/puppetfile_parser_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe 'Ra10ke::PuppetfileParser' do
     end
 
     let(:puppetfile_modules) do
-        [{:args=>{:version=>"2.2.0"}, :name=>"inifile", :namespace=>"puppetlabs"},
+        [{:args=>{:version=>'0.26.2'}, :name=>'choria', :namespace=>nil},
+             {:args=>{:version=>"2.2.0"}, :name=>"inifile", :namespace=>"puppetlabs"},
+             {:args=>{:version=>"1.0.1"}, :name=>"ruby", :namespace=>"puppetlabs"},
              {:args=>{:version=>"4.24.0"}, :name=>"stdlib", :namespace=>"puppetlabs"},
              {:args=>{:version=>"4.0.0"}, :name=>"concat", :namespace=>"puppetlabs"},
              {:args=>{:version=>"6.4.1"}, :name=>"ntp", :namespace=>"puppetlabs"},


### PR DESCRIPTION
A task that checks for deprecated Forge modules

When writing this I noticed that the parser does something interesting on modules where the namespace and name are the same, so I added a test for that as well. Should probably be fixed, but I didn't want to do it as part of this feature.