### PR TITLE
Add handling for additional r10k args in validate for control_branch

### DIFF
--- a/lib/ra10ke/validate.rb
+++ b/lib/ra10ke/validate.rb
@@ -48,7 +48,7 @@ module Ra10ke
             repo = Ra10ke::GitRepo.new(mod[:args][:git])
             ref = mod[:args][:ref] || mod[:args][:tag] || mod[:args][:branch]
             # If using control_branch, try to guesstimate what the target branch should be
-            ref = ENV['CONTROL_BRANCH'] || repo.current_branch || ENV['CONTROL_BRANCH_FALLBACK'] || 'main' \
+            ref = ENV['CONTROL_BRANCH'] || repo.current_branch || mod[:args][:default_branch_override] || ENV['CONTROL_BRANCH_FALLBACK'] || mod[:args][:default_branch] || 'main' \
               if ref == ':control_branch'
             valid_ref = repo.valid_ref?(ref) || repo.valid_commit?(mod[:args][:ref])
             {

--- a/spec/fixtures/Puppetfile_with_control_branch
+++ b/spec/fixtures/Puppetfile_with_control_branch
@@ -6,6 +6,17 @@ mod 'puppet-hiera_control',
   git: 'https://github.com/voxpupuli/puppet-hiera_control.git',
   branch: :control_branch
 
+mod 'puppet-hiera_controlwithdefault',
+  git: 'https://github.com/voxpupuli/puppet-hiera_control.git',
+  branch: :control_branch,
+  default_branch: 'master'
+
+mod 'puppet-hiera_controlwithdefaultoverride',
+  git: 'https://github.com/voxpupuli/puppet-hiera_control.git',
+  branch: :control_branch,
+  default_branch_override: 'master',
+  default_branch: 'devel'
+
 mod 'puppet-hiera_fakecontrol',
   git: 'https://github.com/voxpupuli/puppet-hiera_fakecontrol.git',
   branch: control_branch

--- a/spec/ra10ke/validate_spec.rb
+++ b/spec/ra10ke/validate_spec.rb
@@ -66,23 +66,39 @@ RSpec.describe 'Ra10ke::Validate::Validation' do
 
     it 'correctly replaces control branch' do
       ENV['CONTROL_BRANCH'] = 'env-control_branch'
-      expect(instance.all_modules.find_all { |mod| mod[:ref] == 'env-control_branch' }.count).to eq(1)
+      expect(instance.all_modules.find { |m| m[:name] == 'hiera_control' }[:ref]).to eq('env-control_branch')
     end
 
     it 'correctly detects current branch' do
       allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return('current_branch-control_branch')
-      expect(instance.all_modules.find_all { |mod| mod[:ref] == 'current_branch-control_branch' }.count).to eq(1)
+      expect(instance.all_modules.find { |m| m[:name] == 'hiera_control' }[:ref]).to eq('current_branch-control_branch')
     end
 
     it 'correctly falls back if no current branch' do
       ENV['CONTROL_BRANCH_FALLBACK'] = 'env-control_branch_fallback'
       allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
-      expect(instance.all_modules.find_all { |mod| mod[:ref] == 'env-control_branch_fallback' }.count).to eq(1)
+      expect(instance.all_modules.find { |m| m[:name] == 'hiera_control' }[:ref]).to eq('env-control_branch_fallback')
+    end
+
+    it 'correctly falls back to default_branch if no current branch' do
+      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
+      expect(instance.all_modules.find { |m| m[:name] == 'hiera_controlwithdefault' }[:ref]).to eq('master')
+    end
+
+    it 'correctly falls back to fallback if no current branch but default branch' do
+      ENV['CONTROL_BRANCH_FALLBACK'] = 'env-control_branch_fallback'
+      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
+      expect(instance.all_modules.find { |m| m[:name] == 'hiera_controlwithdefault' }[:ref]).to eq('env-control_branch_fallback')
+    end
+
+    it 'correctly falls back to default_branch if no current branch with override' do
+      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
+      expect(instance.all_modules.find { |m| m[:name] == 'hiera_controlwithdefaultoverride' }[:ref]).to eq('master')
     end
 
     it 'correctly falls back to main if no current branch and no fallback' do
       allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
-      expect(instance.all_modules.find_all { |mod| mod[:ref] == 'main' }.count).to eq(1)
+      expect(instance.all_modules.find { |m| m[:name] == 'hiera_control' }[:ref]).to eq('main')
     end
   end
 


### PR DESCRIPTION
Noticed that I'd missed these keys when I was writing the code, so a late PR that adds an example and tests.

This PR then also handles `default_branch` and `default_branch_override` when dealing with :control_branch, based on how `R10K::Module::Git` does the lookup

The resulting flow for figuring out the correct branch will then be; `$CONTROL_BRANCH` > current branch > `:default_branch_override` > `$CONTROL_BRANCH_FALLBACK` > `:default_branch` > `'main'`