### PR TITLE
Fix source of control_branch data

### DIFF
--- a/lib/ra10ke/git_repo.rb
+++ b/lib/ra10ke/git_repo.rb
@@ -15,11 +15,13 @@ module Ra10ke
       @url = url
     end
 
+    # Get the current branch for a Git repo
+    # @param path [String] - The path to the repository to check
     # @return [String] - The current active branch of the Git repo
-    def current_branch
-      @current_branch ||= begin
+    def self.current_branch(path)
+      Dir.chdir(path) do
         data, success = run_command(CURRENT_BRANCH_CMD)
-        success ? data.strip : nil
+        return success ? data.strip : nil
       end
     end
 
@@ -101,10 +103,14 @@ module Ra10ke
     # @param cmd [String]
     # @param silent [Boolean] set to true if you wish to send output to /dev/null, false by default
     # @return [Array]
-    def run_command(cmd, silent: false)
+    def self.run_command(cmd, silent: false)
       out_args = silent ? '2>&1 > /dev/null' : '2>&1'
       out = `#{cmd} #{out_args}`
       [out, $CHILD_STATUS.success?]
+    end
+
+    def run_command(cmd, silent: false)
+      self.class.run_command(cmd, silent: silent)
     end
   end
 end

--- a/lib/ra10ke/validate.rb
+++ b/lib/ra10ke/validate.rb
@@ -48,8 +48,15 @@ module Ra10ke
             repo = Ra10ke::GitRepo.new(mod[:args][:git])
             ref = mod[:args][:ref] || mod[:args][:tag] || mod[:args][:branch]
             # If using control_branch, try to guesstimate what the target branch should be
-            ref = ENV['CONTROL_BRANCH'] || repo.current_branch || mod[:args][:default_branch_override] || ENV['CONTROL_BRANCH_FALLBACK'] || mod[:args][:default_branch] || 'main' \
-              if ref == ':control_branch'
+            if ref == ':control_branch'
+              r10k_branch = Ra10ke::GitRepo.current_branch(File.dirname(puppetfile))
+              ref = ENV['CONTROL_BRANCH'] \
+                    || r10k_branch \
+                    || mod[:args][:default_branch_override] \
+                    || ENV['CONTROL_BRANCH_FALLBACK'] \
+                    || mod[:args][:default_branch] \
+                    || 'main'
+            end
             valid_ref = repo.valid_ref?(ref) || repo.valid_commit?(mod[:args][:ref])
             {
               name: mod[:name],

--- a/spec/ra10ke/validate_spec.rb
+++ b/spec/ra10ke/validate_spec.rb
@@ -70,34 +70,34 @@ RSpec.describe 'Ra10ke::Validate::Validation' do
     end
 
     it 'correctly detects current branch' do
-      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return('current_branch-control_branch')
+      allow(Ra10ke::GitRepo).to receive(:current_branch).and_return('current_branch-control_branch')
       expect(instance.all_modules.find { |m| m[:name] == 'hiera_control' }[:ref]).to eq('current_branch-control_branch')
     end
 
     it 'correctly falls back if no current branch' do
       ENV['CONTROL_BRANCH_FALLBACK'] = 'env-control_branch_fallback'
-      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
+      allow(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
       expect(instance.all_modules.find { |m| m[:name] == 'hiera_control' }[:ref]).to eq('env-control_branch_fallback')
     end
 
     it 'correctly falls back to default_branch if no current branch' do
-      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
+      allow(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
       expect(instance.all_modules.find { |m| m[:name] == 'hiera_controlwithdefault' }[:ref]).to eq('master')
     end
 
     it 'correctly falls back to fallback if no current branch but default branch' do
       ENV['CONTROL_BRANCH_FALLBACK'] = 'env-control_branch_fallback'
-      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
+      allow(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
       expect(instance.all_modules.find { |m| m[:name] == 'hiera_controlwithdefault' }[:ref]).to eq('env-control_branch_fallback')
     end
 
     it 'correctly falls back to default_branch if no current branch with override' do
-      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
+      allow(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
       expect(instance.all_modules.find { |m| m[:name] == 'hiera_controlwithdefaultoverride' }[:ref]).to eq('master')
     end
 
     it 'correctly falls back to main if no current branch and no fallback' do
-      allow_any_instance_of(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
+      allow(Ra10ke::GitRepo).to receive(:current_branch).and_return(nil)
       expect(instance.all_modules.find { |m| m[:name] == 'hiera_control' }[:ref]).to eq('main')
     end
   end


### PR DESCRIPTION
Realized - when chatting with a colleague - that I was checking the wrong place for figuring out the correct `:control_branch` value.
With this PR it should use the correct repository for that.