### PR TITLE
Dependencies Table output 

### DIFF
--- a/lib/ra10ke/dependencies.rb
+++ b/lib/ra10ke/dependencies.rb
@@ -1,63 +1,79 @@
+require 'semverse'
+require 'r10k/puppetfile'
+require 'puppet_forge'
+require 'table_print'
+require 'git'
+
 module Ra10ke::Dependencies
-  @@version_formats = {}
+  class Verification
 
-  # Registers a block that finds the latest version.
-  # The block will be called with a list of tags.
-  # If the block returns nil the next format will be tried.
-  def self.register_version_format(name, &block)
-    @@version_formats[name] = block
-  end
+    def self.version_formats
+      @version_formats ||= {}
+    end
 
-  # semver is the default version format.
-  register_version_format(:semver) do |tags|
-    latest_tag = tags.map do |tag|
-      begin
-        Semverse::Version.new tag[/\Av?(.*)\Z/, 1]
-      rescue Semverse::InvalidVersionFormat
-        # ignore tags that do not comply to semver
-        nil
-      end
-    end.select { |tag| !tag.nil? }.sort.last.to_s.downcase
-    latest_ref = tags.detect { |tag| tag[/\Av?(.*)\Z/, 1] == latest_tag }
-  end
+    # Registers a block that finds the latest version.
+    # The block will be called with a list of tags.
+    # If the block returns nil the next format will be tried.
+    def self.register_version_format(name, &block)
+      version_formats[name] = block
+    end
 
-  def get_latest_ref(remote_refs)
-    tags = remote_refs['tags'].keys
-    latest_ref = nil
-    @@version_formats.detect { |_, block| latest_ref = block.call(tags) }
-    latest_ref = 'undef (tags do not follow any known pattern)' if latest_ref.nil?
-    latest_ref
-  end
-
-  def define_task_dependencies(*_args)
-    desc "Print outdated forge modules"
-    task :dependencies do
-      require 'r10k/puppetfile'
-      require 'puppet_forge'
-
-      PuppetForge.user_agent = "ra10ke/#{Ra10ke::VERSION}"
-      puppetfile = get_puppetfile
-      puppetfile.load!
-      PuppetForge.host = puppetfile.forge if puppetfile.forge =~ /^http/
-
-      # ignore file allows for "don't tell me about this"
-      ignore_modules = []
-      if File.exist?('.r10kignore')
-        ignore_modules = File.readlines('.r10kignore').each {|l| l.chomp!}
-      end
-
-      puppetfile.modules.each do |puppet_module|
-        next if ignore_modules.include? puppet_module.title
-        if puppet_module.class == R10K::Module::Forge
-          module_name = puppet_module.title.gsub('/', '-')
-          forge_version = PuppetForge::Module.find(module_name).current_release.version
-          installed_version = puppet_module.expected_version
-          if installed_version != forge_version
-            puts "#{puppet_module.title} is OUTDATED: #{installed_version} vs #{forge_version}"
-          end
+    Ra10ke::Dependencies::Verification.register_version_format(:semver) do |tags|
+      latest_tag = tags.map do |tag|
+        begin
+          Semverse::Version.new tag[/\Av?(.*)\Z/, 1]
+        rescue Semverse::InvalidVersionFormat
+          # ignore tags that do not comply to semver
+          nil
         end
+      end.select { |tag| !tag.nil? }.sort.last.to_s.downcase
+      latest_ref = tags.detect { |tag| tag[/\Av?(.*)\Z/, 1] == latest_tag }
+    end
+    attr_reader :puppetfile
 
-        if puppet_module.class == R10K::Module::Git
+    def initialize(pfile)
+      @puppetfile = pfile
+       # semver is the default version format.
+  
+      puppetfile.load!
+    end
+
+    def get_latest_ref(remote_refs)
+      tags = remote_refs['tags'].keys
+      latest_ref = nil
+      self.class.version_formats.detect { |_, block| latest_ref = block.call(tags) }
+      latest_ref = 'undef (tags do not follow any known pattern)' if latest_ref.nil?
+      latest_ref
+    end
+
+    def ignored_modules
+      # ignore file allows for "don't tell me about this"
+      @ignored_modules ||= begin
+        File.readlines('.r10kignore').each {|l| l.chomp!} if File.exist?('.r10kignore')
+      end || []
+    end
+  
+    # @summary creates an array of module hashes with version info 
+    # @param {Object} supplied_puppetfile - the parsed puppetfile object 
+    # @returns {Array} array of version info for each module
+    # @note does not include ignored modules or modules up2date
+    def processed_modules(supplied_puppetfile = puppetfile)
+
+      supplied_puppetfile.modules.map do |puppet_module|
+        next if ignored_modules.include? puppet_module.title
+        if puppet_module.class == ::R10K::Module::Forge
+          module_name = puppet_module.title.gsub('/', '-')
+          forge_version = ::PuppetForge::Module.find(module_name).current_release.version
+          installed_version = puppet_module.expected_version
+          {
+            name: puppet_module.title,
+            installed: installed_version,
+            latest: forge_version,
+            type: 'forge',
+            message: installed_version != forge_version ? :outdated : :current
+          }
+        
+        elsif puppet_module.class == R10K::Module::Git
           # use helper; avoid `desired_ref`
           # we do not want to deal with `:control_branch`
           ref = puppet_module.version
@@ -79,15 +95,44 @@ module Ra10ke::Dependencies
             # Ra10ke::Dependencies.register_version_format(:name, &block)
             latest_ref = get_latest_ref(remote_refs)
           elsif ref.match(/^[a-z0-9]{40}$/)
+            ref = ref.slice(0,8)
             # for sha just assume head should be tracked
-            latest_ref = remote_refs['head'][:sha]
+            latest_ref = remote_refs['head'][:sha].slice(0,8)
           else
             raise "Unable to determine ref type for #{puppet_module.title}"
           end
+          {
+            name: puppet_module.title,
+            installed: ref,
+            latest: latest_ref,
+            type: 'git',
+            message: ref != latest_ref ? :outdated : :current
+          }
 
-          puts "#{puppet_module.title} is OUTDATED: #{ref} vs #{latest_ref}" if ref != latest_ref
         end
+      end.compact
+    end
+
+    def outdated(supplied_puppetfile = puppetfile)
+      processed_modules.find_all do | mod |
+        mod[:message] == :outdated
       end
+    end
+
+    def print_table(mods)
+      puts
+      tp mods, { name: { width: 50 } }, :installed, :latest, :type, :message
+    end
+  end
+
+  def define_task_dependencies(*_args)
+    desc "Print outdated forge modules"
+    task :dependencies do
+      PuppetForge.user_agent = "ra10ke/#{Ra10ke::VERSION}"
+      puppetfile = get_puppetfile
+      PuppetForge.host = puppetfile.forge if puppetfile.forge =~ /^http/
+      dependencies = Ra10ke::Dependencies::Verification.new(puppetfile)
+      dependencies.print_table(dependencies.outdated)
     end
   end
 end

--- a/ra10ke.gemspec
+++ b/ra10ke.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rake"
   spec.add_dependency "puppet_forge"
-  spec.add_dependency "r10k"
+  spec.add_dependency "r10k", '>= 2.6.5'
   spec.add_dependency "git"
   spec.add_dependency "solve"
   spec.add_dependency 'semverse', '>= 2.0'

--- a/spec/ra10ke/dependencies_spec.rb
+++ b/spec/ra10ke/dependencies_spec.rb
@@ -1,34 +1,56 @@
 # frozen_string_literal: true
-
+require 'r10k/puppetfile'
 require 'spec_helper'
 require 'ra10ke/dependencies'
 RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
 RSpec.describe 'Ra10ke::Dependencies::Verification' do
-  after(:each) do
-    # reset version formats
-    formats = Ra10ke::Dependencies.class_variable_get(:@@version_formats)
-    Ra10ke::Dependencies.class_variable_set(:@@version_formats, formats.select { |k, _v| k == :semver } )
+  let(:instance) do
+    pfile = R10K::Puppetfile.new(File.basename(puppetfile), nil,puppetfile, nil, false)
+    Ra10ke::Dependencies::Verification.new(pfile)
+  end
+
+  let(:puppetfile) do
+    File.join(fixtures_dir, 'Puppetfile')
   end
 
   context 'register_version_format' do
     it 'default contains semver' do
-      expect(Ra10ke::Dependencies.class_variable_get(:@@version_formats)).to have_key(:semver)
+      expect(Ra10ke::Dependencies::Verification.version_formats).to have_key(:semver)
     end
     it 'add new version format' do
-      Ra10ke::Dependencies.register_version_format(:test) do |tags|
+      Ra10ke::Dependencies::Verification.register_version_format(:test) do |tags|
         nil
       end
-      expect(Ra10ke::Dependencies.class_variable_get(:@@version_formats)).to have_key(:test)
+      expect(Ra10ke::Dependencies::Verification.version_formats).to have_key(:test)
     end
   end
 
-  context 'get_latest_ref' do
+  context 'show output in table format' do
     let(:instance) do
-      class DependencyDummy
-        include Ra10ke::Dependencies
-      end.new
+      pfile = R10K::Puppetfile.new(File.basename(puppetfile), nil,puppetfile, nil, false)
+      Ra10ke::Dependencies::Verification.new(pfile)
     end
+  
+    let(:puppetfile) do
+      File.join(fixtures_dir, 'Puppetfile')
+    end
+
+    let(:processed_modules) do
+      instance.outdated
+    end
+
+    it 'have dependencies array' do
+      expect(processed_modules).to be_a Array
+    end
+
+    it 'show dependencies as table' do
+      instance.print_table(processed_modules)
+    end
+
+  end
+
+  context 'get_latest_ref' do
 
     context 'find latest semver tag' do
       let(:latest_tag) do
@@ -60,13 +82,13 @@ RSpec.describe 'Ra10ke::Dependencies::Verification' do
       end
 
       it do
-        Ra10ke::Dependencies.register_version_format(:number) do |tags|
+        Ra10ke::Dependencies::Verification.register_version_format(:number) do |tags|
           tags.detect { |tag| tag == latest_tag }
         end
         expect(instance.get_latest_ref({
           'tags' => test_tags,
         })).to eq(latest_tag)
       end
-    end
+     end
   end
 end


### PR DESCRIPTION
Takes the boring old output and converts it to a nice table.

From this:

```
puppetlabs-reboot is OUTDATED: 1.2.1 vs 4.1.0
puppetlabs-registry is OUTDATED: 1.1.4 vs 4.0.1
puppetlabs-powershell is OUTDATED: 2.1.0 vs 5.0.0
puppetlabs-acl is OUTDATED: 1.1.2 vs 4.0.0
puppetlabs-wsus_client is OUTDATED: 1.0.3 vs 4.0.0

```
to 

```
NAME               | INSTALLED | LATEST   | TYPE  | MESSAGE 
-------------------|-----------|----------|-------|---------
choria-choria      | 0.26.2    | 0.27.1   | forge | outdated
puppetlabs-inifile | 2.2.0     | 5.2.0    | forge | outdated
puppetlabs-stdlib  | 4.24.0    | 8.1.0    | forge | outdated
puppetlabs-concat  | 4.0.0     | 7.1.1    | forge | outdated
puppetlabs-ntp     | 6.4.1     | 9.1.0    | forge | outdated
puppet-archive     | 3.1.1     | 6.0.2    | forge | outdated
gitlab             | 00397b86  | e5447cb6 | git   | outdated
r10k               | v3.1.1    | v3.2.0   | git   | outdated
pltraining-rbac    | 2f60e178  | e891bea7 | git   | outdated
```