### PR TITLE
Converts puppet forge module entries into puppetfile git entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ Ignoring specific modules:
 Under specific conditions you may not wish to report on specific modules being out of date,
 to ignore a module create `.r10kignore` file in the same directory as your Puppetfile.
 
+### r10k::print_git_conversion
+This rake task will go through the puppetfile and convert forge based modules into git based modules using
+the modules't source repository and version tag.
+
+This feature is useful when you want to bring all the forge modules into git source control.  This assumes every module
+tags the release or provides a valid repo url.  We recommend to manually review
+the output provided by this task before replacing the forge based content in your puppetfile as not every module author 
+tagged a release or provided a working url.
+
 ### r10k:solve_dependencies
 
 Reads the Puppetfile in the current directory and uses the ruby 'solve' library to find

--- a/lib/ra10ke.rb
+++ b/lib/ra10ke.rb
@@ -41,6 +41,7 @@ module Ra10ke
         define_task_duplicates(*args)
         define_task_install(*args)
         define_task_validate(*args)
+        define_task_print_git_conversion(*args)
       end
     end
 

--- a/lib/ra10ke/git_repo.rb
+++ b/lib/ra10ke/git_repo.rb
@@ -85,8 +85,8 @@ module Ra10ke
       @all_refs ||= begin
         remote_refs.each_with_object([]) do |line, refs|
           sha, ref = line.split("\t")
+          next refs if line.include?('redirecting')
           next refs if sha.eql?('ref: refs/heads/master')
-
           _, type, name, subtype = ref.chomp.split('/')
           next refs unless name
 
@@ -97,6 +97,18 @@ module Ra10ke
           refs << { sha: sha, ref: ref.chomp, type: type, subtype: subtype, name: name }
         end
       end
+    end
+
+    # @summary searches all the refs for a ref similar to the name provided
+    #          This is useful when looking for tags if a v or not a v
+    # @param ref_name [String]
+    # @return [String] the matching ref_name or nil
+    def get_ref_like(ref_name)
+      return nil unless valid_url?
+      ref = all_refs.find do |ref|
+        ref[:name].include?(ref_name)
+      end
+      ref
     end
 
     # useful for mocking easily

--- a/spec/fixtures/Puppetfile_git_conversion
+++ b/spec/fixtures/Puppetfile_git_conversion
@@ -1,0 +1,28 @@
+mod 'choria',
+  :git => 'https://github.com/choria-io/puppet-choria',
+  :ref => '0.26.2'
+
+mod 'inifile',
+  :git => 'https://github.com/puppetlabs/puppetlabs-inifile',
+  :ref => '2.2.0'
+
+mod 'ruby',
+  :git => 'https://github.com/puppetlabs/puppetlabs-ruby.git',
+  :ref => 'v1.0.1'
+
+mod 'stdlib',
+  :git => 'https://github.com/puppetlabs/puppetlabs-stdlib',
+  :ref => '4.24.0'
+
+mod 'concat',
+  :git => 'https://github.com/puppetlabs/puppetlabs-concat',
+  :ref => '4.0.0'
+
+mod 'ntp',
+  :git => 'https://github.com/puppetlabs/puppetlabs-ntp',
+  :ref => '6.4.1'
+
+mod 'archive',
+  :git => 'https://github.com/voxpupuli/puppet-archive',
+  :ref => 'v3.1.1'
+

--- a/spec/ra10ke/dependencies_spec.rb
+++ b/spec/ra10ke/dependencies_spec.rb
@@ -2,6 +2,8 @@
 require 'r10k/puppetfile'
 require 'spec_helper'
 require 'ra10ke/dependencies'
+require 'ra10ke'
+
 RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
 RSpec.describe 'Ra10ke::Dependencies::Verification' do
@@ -89,6 +91,18 @@ RSpec.describe 'Ra10ke::Dependencies::Verification' do
           'tags' => test_tags,
         })).to eq(latest_tag)
       end
-     end
+    end
+
+    context 'convert to ref' do
+       
+      it 'run rake task' do
+        output_conversion = File.read(File.join(fixtures_dir, 'Puppetfile_git_conversion'))
+        require 'ra10ke'
+        Ra10ke::RakeTask.new do |t|
+          t.basedir = fixtures_dir
+        end
+        expect{Rake::Task['r10k:print_git_conversion'].invoke}.to output(output_conversion).to_stdout
+      end
+    end
   end
 end

--- a/spec/ra10ke/git_repo_spec.rb
+++ b/spec/ra10ke/git_repo_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe 'Ra10ke::GitRepo' do
       expect(instance.remote_refs.first).to eq("1b3322d525e96bf7d0565b08703e2a44c90e7b4a\tHEAD\n")
     end
 
+    it '#get_ref_like' do
+      expect(instance.get_ref_like('8.0.0'))
+    end
+
     it '#valid_ref?' do
       expect(instance.valid_ref?('master')).to be true
     end


### PR DESCRIPTION
  * This feature is useful when you want to bring all the forge modules
    in house on the local git server.  This will auto lookup
    the module's homepage url and use that as the git source.

    Sometimes the author doesn't provide the homepage url so this
    will fail and the code isn't always tagged to the version so
    some manual intervention will be required before final approval
    of conversion output.

Example: `bundle exec rake r10k:print_git_conversion`

Converts the following

```ruby
# # In addition to the component modules listed here, the 'site' directory
# # includes 'role' and 'profile' modules. The 'role' module contains
# # Puppet classes that constitute a machine role or business function.
# #
# # Start Forge Modules
# # puppetlabs/windows pack
mod 'puppetlabs/reboot'
mod 'puppetlabs/registry',                 '1.1.4'
mod 'puppetlabs/powershell',               '2.1.0'
mod 'puppetlabs/acl',                      '1.1.2'
mod 'puppetlabs/wsus_client',              '1.0.3'
mod 'puppetlabs/chocolatey',               '3.0.0'
mod 'puppet/download_file',                '2.1.0'
mod 'puppet/windowsfeature',               '2.1.0'
mod 'puppet/windows_env',                  '2.3.0'
mod 'noma4i/windows_updates',              '0.2.2'
mod 'ianoberst/xml_fragment',              '1.0.2'
```
into


```ruby
mod 'reboot',
  :git => 'https://github.com/puppetlabs/puppetlabs-reboot',
  :ref => 'v4.1.0'

mod 'registry',
  :git => 'https://github.com/puppetlabs/puppetlabs-registry',
  :ref => '1.1.4'

mod 'powershell',
  :git => 'https://github.com/puppetlabs/puppetlabs-powershell',
  :ref => '2.1.0'

mod 'acl',
  :git => 'https://github.com/puppetlabs/puppetlabs-acl',
  :ref => '1.1.2'

mod 'wsus_client',
  :git => 'https://github.com/puppetlabs/puppetlabs-wsus_client',
  :ref => '1.0.3'

mod 'chocolatey',
  :git => 'https://github.com/puppetlabs/puppetlabs-chocolatey',
  :ref => '3.0.0'

mod 'download_file',
  :git => 'https://github.com/voxpupuli/puppet-download_file',
  :ref => 'v2.1.0'

mod 'windowsfeature',
  :git => 'https://github.com/voxpupuli/puppet-windowsfeature',
  :ref => 'v2.1.0'

mod 'windows_env',
  :git => 'https://github.com/voxpupuli/puppet-windows_env',
  :ref => 'v2.3.0'

mod 'windows_updates',
  :git => 'https://github.com/noma4i/puppet-windows_updates',
  :ref => 'bad url or tag 0.2.2 is missing'

mod 'xml_fragment',
  :git => 'https://github.com/Areson/xml_fragment',
  :ref => 'bad url or tag 1.0.2 is missing'
```
