### PR TITLE
Bump minimal Ruby Version 2.4.0->2.7.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "2.4"
-          - ruby: "2.5"
-          - ruby: "2.6"
           - ruby: "2.7"
           - ruby: "3.0"
             coverage: "yes"

--- a/ra10ke.gemspec
+++ b/ra10ke.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files`.split($/)
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_dependency "rake"
   spec.add_dependency "puppet_forge"


### PR DESCRIPTION
We already have one backwards-incompatible change merges so we could use this to also cleanup the ruby versions. 2.4, 2.5 and 2.6 are EoL:
https://www.ruby-lang.org/en/downloads/branches/