### PR TITLE
Require Ruby 3.1 & puppet_forge 6 & r10k 5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "2.7"
-          - ruby: "3.0"
           - ruby: "3.1"
             coverage: "yes"
           - ruby: "3.2"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,6 @@ inherit_from: .rubocop_todo.yml
 
 inherit_gem:
   voxpupuli-rubocop: rubocop.yml
+
+AllCops:
+  TargetRubyVersion: '3.1'

--- a/ra10ke.gemspec
+++ b/ra10ke.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'git', '>= 1.18', '< 3.0'
   spec.add_dependency 'puppet_forge', '~> 6.0'
-  spec.add_dependency 'r10k', '>= 2.6.5', '< 5'
+  spec.add_dependency 'r10k', '~> 5.0'
   spec.add_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_dependency 'semverse', '>= 2.0', '< 4'
   spec.add_dependency 'solve', '~> 4.0', '>= 4.0.4'

--- a/ra10ke.gemspec
+++ b/ra10ke.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files`.split($/)
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.add_dependency 'git', '>= 1.18', '< 3.0'
-  spec.add_dependency 'puppet_forge', '~> 5.0', '>= 5.0.1'
+  spec.add_dependency 'puppet_forge', '~> 6.0'
   spec.add_dependency 'r10k', '>= 2.6.5', '< 5'
   spec.add_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_dependency 'semverse', '>= 2.0', '< 4'


### PR DESCRIPTION
This allows us to use the latest version of puppet_forge client.