### PR TITLE
Cleanup Rakefile; remove unused rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,4 @@
-require 'rake'
-require 'rake/clean'
-require 'rubygems'
-require 'bundler/gem_tasks'
-require 'fileutils'
-require 'rspec/core'
 require 'rspec/core/rake_task'
-
-CLEAN.include('pkg/', 'tmp/')
-CLOBBER.include('Gemfile.lock')
 
 task default: [:spec]
 


### PR DESCRIPTION
We included rake tasks to build the gem, but out pipeline doesn't use it. We always build with `gem build`.